### PR TITLE
fix: change TNMG lead parsing from int16 to int32

### DIFF
--- a/ecgprep/read_ecg.py
+++ b/ecgprep/read_ecg.py
@@ -118,13 +118,13 @@ def read_musexml_KI(file):
 
 
 def read_lead(string_representation):
-    return np.array([int(n) for n in string_representation.split(';') if n], dtype='<i2')
+    return np.array([int(n) for n in string_representation.split(';') if n], dtype='<i4')
 
 
 def read_all_leads(c, leads):
     l1 = read_lead(c[leads[0]])
     n = len(l1)
-    ecg = np.zeros((len(leads), n), dtype='<i2')
+    ecg = np.zeros((len(leads), n), dtype='<i4')
     ecg[0, :] = l1
     leads_available = []
     leads_available.append(leads[0])


### PR DESCRIPTION
## Summary
- Change `read_lead()` and `read_all_leads()` dtype from `<i2` (int16) to `<i4` (int32)
- Avoids integer overflow when TNMG JSON contains values outside the int16 range ([-32768, 32767])

## Changes
Two lines in `ecgprep/read_ecg.py`:
```python
# read_lead: dtype='<i2' → dtype='<i4'
# read_all_leads: dtype='<i2' → dtype='<i4'
```

## Backward compatibility
- int32 is a superset of int16 — all existing TNMG data that fits in int16 works identically
- `convert_to_mv()` operates on numpy arrays and is dtype-agnostic, so no changes needed there
- No impact on WFDB or MuseXML reading paths (they don't use `read_lead`)